### PR TITLE
[S3 upload] Add multiPart check for big memory size

### DIFF
--- a/cmd/memr/output.go
+++ b/cmd/memr/output.go
@@ -14,7 +14,7 @@ import (
 	"github.com/golang/snappy"
 )
 
-func S3Writer(reader io.ReadCloser, compress bool, region, bucket, key string, concurrency int) (*manager.UploadOutput, error) {
+func S3Writer(reader io.ReadCloser, compress bool, region, bucket, key string, concurrency int, memory_size uint64) (*manager.UploadOutput, error) {
 
 	cfg, err := config.LoadDefaultConfig(context.TODO(),
 		// client will only use this region if none is otherwise set using AWS_REGION or AWS_DEFAULT_REGION
@@ -24,13 +24,23 @@ func S3Writer(reader io.ReadCloser, compress bool, region, bucket, key string, c
 		return nil, err
 	}
 
+	// Set size of multi part upload; by default the minimal is 5Mb
+	// A lower value here will have a lesser impact on memory pressure, and should be considered
+	// Increasing this value will directly impact how much memory we use
+	// Minimal size when possible will allow max 50GB memory size (5MB * 10.000)
+	var partSize int64
+	if uint64(manager.MaxUploadParts) * uint64(manager.MinUploadPartSize) > memory_size {
+		partSize = manager.MinUploadPartSize
+	} else {
+		// For bigger memory than 50GB, we calculate the size of the part
+		// part size = (memory size / max upload parts) + 1MB
+		partSize = int64(memory_size / uint64(manager.MaxUploadParts)) + (1024 * 1024)
+	}
+	log.Printf("[DEBUG] S3 part size set up to %d MBs", partSize/1024/1024)
+
 	// Create an uploader with the session and custom options
 	uploader := manager.NewUploader(s3.NewFromConfig(cfg), func(u *manager.Uploader) {
-		u.PartSize = manager.MinUploadPartSize // 5MB (smallest allowed)
-		// 5 goroutines is the default. A lower value here will have a lesser
-		// impact on memory pressure, and should be considered
-		// Increasing this value will directly impact how much memory we use
-		// set to manager.DefaultUploadConcurrency by default
+		u.PartSize = partSize
 		u.Concurrency = concurrency
 
 		// A buffer provider could be used to allow for larger buffers (64 KiB?) in memory

--- a/cmd/memr/output.go
+++ b/cmd/memr/output.go
@@ -27,14 +27,13 @@ func S3Writer(reader io.ReadCloser, compress bool, region, bucket, key string, c
 	// Set size of multi part upload; by default the minimal is 5Mb
 	// A lower value here will have a lesser impact on memory pressure, and should be considered
 	// Increasing this value will directly impact how much memory we use
-	// Minimal size when possible will allow max 50GB memory size (5MB * 10.000)
-	var partSize int64
-	if uint64(manager.MaxUploadParts) * uint64(manager.MinUploadPartSize) > memory_size {
-		partSize = manager.MinUploadPartSize
-	} else {
+	// Minimal size when possible will allow max 50GB memory size (5MB * 10,000)
+	const padSize = 1024 * 1024  // Use an extra mb as padding, just in case
+	var partSize int64 = manager.MinUploadPartSize  // Default to minimum part size (5MB)
+	if memory_size + padSize > uint64(manager.MaxUploadParts) * uint64(manager.MinUploadPartSize) {
 		// For bigger memory than 50GB, we calculate the size of the part
 		// part size = (memory size / max upload parts) + 1MB
-		partSize = int64(memory_size / uint64(manager.MaxUploadParts)) + (1024 * 1024)
+		partSize = int64(memory_size / uint64(manager.MaxUploadParts)) + padSize
 	}
 	log.Printf("[DEBUG] S3 part size set up to %d MBs", partSize/1024/1024)
 

--- a/cmd/memr/root.go
+++ b/cmd/memr/root.go
@@ -102,7 +102,7 @@ memr --compress=false  --local-file <FILE>`,
 		} else {
 
 			// Not using a local file, so assume s3
-			res, err := S3Writer(reader, compress, region, s3Bucket, s3ObjectKey, concurrency)
+			res, err := S3Writer(reader, compress, region, s3Bucket, s3ObjectKey, concurrency, reader.Size())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Add a check where if max multi part * minimal part size is smaller than memory size, we calculate the correct part size to support bit memory rams.

![image](https://user-images.githubusercontent.com/12594828/159751271-e435e878-dd29-4484-90a9-16c2d3324670.png)
